### PR TITLE
Make install_requires more explicit

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -22,8 +22,8 @@ install:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
   # Print the Python version for easier debugging
   - python --version
-  # Upgrade pip, setuptools and wheel
-  - python -m pip install --upgrade pip setuptools wheel
+  # Upgrade pip, and setuptools
+  - python -m pip install --upgrade pip setuptools
   # Use `pip install .` instead of `setup.py install`
   - python -m pip install .
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,8 +43,8 @@ task:
   install_script:
     # Print Python version for easier debugging
     - python3 --version
-    # Upgrade pip, setuptools and wheel
-    - python3 -m pip install --upgrade pip setuptools wheel
+    # Upgrade pip, and setuptools
+    - python3 -m pip install --upgrade pip setuptools
     # Use `pip install .` instead of `setup.py install`
     - python3 -m pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ matrix:
 install:
   # Print the Python version for easier debugging
   - python --version
-  # Upgrade pip, setuptools and wheel
-  - python -m pip install --upgrade pip setuptools wheel
+  # Upgrade pip, and setuptools
+  - python -m pip install --upgrade pip setuptools
   # Use `pip install .` instead of `setup.py install`
   - python -m pip install .
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ packages.
 
 ## Install
 
-- Clone or download the repository from GitHub (e.g. `git clone https://github
-.com/pzahemszky/pZudoku.git`).
+- Clone or download the repository from GitHub (e.g. `git clone https://github.com/pzahemszky/pZudoku.git`).
 - Change to the `pZudoku` directory (e.g. `cd pZudoku`).
 - Install the `pZudoku` Python package (e.g. `pip install --user .`).
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ A Python 3 implementation of a sudoku solver, using my own 6D boolean array data
 
 ## Prerequisites
 
-You'll need Python 3, as well as the following packages installed.
-- `pip`
-- `setuptools`
-- `numpy`
+You'll need Python 3 installed (3.4 or later), as well as the following
+packages.
+- `pip >= 9.0.0`
+- `setuptools >= 38.6.0`
+- `numpy >= 1.8.0`
+
+[//]: # (Note: keep these in sync with setup.py's install_requires)
 
 ## Install
 

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,17 @@ setuptools.setup(
     keywords='sudoku sudoku-solver',
 
     packages=setuptools.find_packages(exclude=['tests']),
+
     # Requirements installed by `python setup.py install`
-    install_requires=["numpy >= 1.14.2"],
+    install_requires=[
+        # pip 9.0.0 notifies about python_requires incompatibility
+        "pip >= 9.0.0",
+        # setuptools 38.6.0 introduces long_description_content_type
+        "setuptools >= 38.6.0",
+        # NumPy 1.8.0 introduces np.full()
+        "numpy >= 1.8.0",
+    ],
+
     python_requires=">=3.4",
     tests_require=["flake8 >= 3.4", "coverage >= 4.5.2", "codecov"],
 


### PR DESCRIPTION
Prerequisites (in the README, as well as in `setup.py`'s `install_requires`):
- `pip >= 9.0.0`
- `setuptools >= 38.6.0`
- `numpy >= 1.8.0`