### PR TITLE
Add a Python 3.8 job to Travis CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,10 @@ task:
           image: python:3.6
           image: python:3.5
           image: python:3.4
+    # Allow failures for development versions of Python
+    - allow_failures: true
+      container:
+        image: python:3.8-rc
 
     - osx_instance:
         matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,10 +11,6 @@ task:
           image: python:3.6
           image: python:3.5
           image: python:3.4
-    # Allow failures for development versions of Python
-    - allow_failures: true
-      container:
-        image: python:3.8-rc
 
     - osx_instance:
         matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ matrix:
     # Enumerate all possible combinations, because the other option doesn't seem to work
     - os: linux
       dist: xenial
+      python: "3.8-dev"
+    - os: linux
+      dist: xenial
       python: "3.7"
-      # No Python 3.7 archives for Trusty or Precise
+      # No Python 3.7 or 3.8-dev archives for Trusty or Precise
       # See https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
     - os: linux
       dist: xenial
@@ -37,6 +40,11 @@ matrix:
       dist: precise
       python: "3.4"
     # To add macOS here, see https://docs.travis-ci.com/user/multi-os/#python-example-unsupported-languages
+  # Only wait for required builds to finish
+  fast_finish: true
+  allow_failures:
+    # Allow failures for development versions of Python
+    - python: "3.8-dev"
 
 install:
   # Print the Python version for easier debugging


### PR DESCRIPTION
Add a Python 3.8 job to Travis CI to track behaviour with the next major release of Python