### PR TITLE
Drop support for macOS High Sierra and Python 3.4 on Ubuntu Precise

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,6 @@ task:
     - osx_instance:
         matrix:
           image: mojave-base
-          image: high-sierra-base
       container:
         # This has Python 2.7
         image: python:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ matrix:
     - os: linux
       dist: trusty
       python: "3.4"
-    - os: linux
-      dist: precise
-      python: "3.4"
     # To add macOS here, see https://docs.travis-ci.com/user/multi-os/#python-example-unsupported-languages
   # Only wait for required builds to finish
   fast_finish: true


### PR DESCRIPTION
Drop support for macOS High Sierra and Python 3.4 on Ubuntu Precise