### PR TITLE
Add Python 3.8 jobs to AppVeyor

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -7,6 +7,8 @@ image:
 environment:
   matrix:
     # Different Python versions to run tests with
+    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python36-x64"

--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -19,10 +19,15 @@ environment:
     - PYTHON: "C:\\Python34"
     # Codecov token not needed for AppVeyor
 
-# Exclude Visual Studio 2017, Python 3.4 configuration from build matrix
-# See issue #89
 matrix:
   exclude:
+    # No Python 3.8 on Visual Studio 2013
+    - image: Visual Studio 2013
+      PYTHON: "C:\\Python38-x64"
+    - image: Visual Studio 2013
+      PYTHON: "C:\\Python38"
+    # Exclude Visual Studio 2017, Python 3.4 configuration from build matrix
+    # See pzahemszky/pZudoku#89
     - image: Visual Studio 2017
       PYTHON: "C:\\Python34-x64"
     - image: Visual Studio 2017

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ TROVE_CLASSIFIERS = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Games/Entertainment :: Puzzle Games",
 ]


### PR DESCRIPTION
Add Python 3.8 jobs to AppVeyor. Related to #95.
