### PR TITLE
Remove Python 3.4 CI jobs

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -15,8 +15,6 @@ environment:
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python34-x64"
-    - PYTHON: "C:\\Python34"
     # Codecov token not needed for AppVeyor
 
 matrix:
@@ -26,12 +24,6 @@ matrix:
       PYTHON: "C:\\Python38-x64"
     - image: Visual Studio 2013
       PYTHON: "C:\\Python38"
-    # Exclude Visual Studio 2017, Python 3.4 configuration from build matrix
-    # See pzahemszky/pZudoku#89
-    - image: Visual Studio 2017
-      PYTHON: "C:\\Python34-x64"
-    - image: Visual Studio 2017
-      PYTHON: "C:\\Python34"
 
 install:
   # Put the Python executable on `PATH`

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,6 @@ task:
           image: python:3.7
           image: python:3.6
           image: python:3.5
-          image: python:3.4
 
     - osx_instance:
         matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,6 @@ matrix:
     - os: linux
       dist: precise
       python: "3.5"
-    - os: linux
-      dist: xenial
-      python: "3.4"
-    - os: linux
-      dist: trusty
-      python: "3.4"
     # To add macOS here, see https://docs.travis-ci.com/user/multi-os/#python-example-unsupported-languages
   # Only wait for required builds to finish
   fast_finish: true


### PR DESCRIPTION
Remove Python 3.4 CI jobs.

From [PEP 429](https://www.python.org/dev/peps/pep-0429/):

> Python 3.4 has now reached its end-of-life and has been retired. No more releases will be made.