### PR TITLE
Replace `setup.py test` with `-m unittest discover`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   # Upgrade pip, and setuptools
   - python -m pip install --upgrade pip setuptools
   # Use `pip install .` instead of `setup.py install`
-  - python -m pip install .
+  - python -m pip install .[dev]
 
 script:
   # Run the PEP8 code style checks
@@ -24,7 +24,7 @@ script:
   - flake8 --filename=*.py --ignore= --exclude=venv,.eggs .
   # Run tests and compute code coverage
   - python -m pip install coverage
-  - coverage run -m unittest discover --verbose
+  - coverage run -m unittest discover --verbose pZudoku
   # Codecov report
   - python -m pip install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,16 @@ install:
   # Upgrade pip, and setuptools
   - python -m pip install --upgrade pip setuptools
   # Use `pip install .` instead of `setup.py install`
-  - python -m pip install .[dev]
+  - python -m pip install .
+  # Install the minimal set of packages needed for running the tests under coverage
+  - python -m pip install --no-deps coverage
 
 script:
-  # Run the PEP8 code style checks
-  - flake8 --filename=*.py --ignore= --exclude=venv,.eggs .
   # Run tests and compute code coverage
   - coverage run -m unittest discover --verbose pZudoku
+  # Install the dependencies of the "dev" extra
+  - python -m pip install .[dev]
+  # Run the PEP8 code style checks
+  - flake8 --filename=*.py --ignore= --exclude=venv,.eggs .
   # Codecov report
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - flake8 --filename=*.py --ignore= --exclude=venv,.eggs .
   # Run tests and compute code coverage
   - python -m pip install coverage
-  - coverage run -m unittest discover
+  - coverage run -m unittest discover --verbose
   # Codecov report
   - python -m pip install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - flake8 --filename=*.py --ignore= --exclude=venv,.eggs .
   # Run tests and compute code coverage
   - python -m pip install coverage
-  - coverage run setup.py test
+  - coverage run -m unittest discover
   # Codecov report
   - python -m pip install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,8 @@ install:
 
 script:
   # Run the PEP8 code style checks
-  - python -m pip install flake8
   - flake8 --filename=*.py --ignore= --exclude=venv,.eggs .
   # Run tests and compute code coverage
-  - python -m pip install coverage
   - coverage run -m unittest discover --verbose pZudoku
   # Codecov report
-  - python -m pip install codecov
   - codecov

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,11 @@ setuptools.setup(
     ],
 
     python_requires=">=3.4",
-    tests_require=["flake8 >= 3.4", "coverage >= 4.5.2", "codecov"],
+    extras_require={
+        "dev": ["flake8 >= 3.4", "coverage >= 4.5.2", "codecov"],
+    },
 
     project_urls={
         "Tracker": "https://github.com/pzahemszky/pZudoku/issues",
     },
-
-    # Test run by `python setup.py test`
-    test_suite="pZudoku.tests",
 )


### PR DESCRIPTION
- Formally remove test dependencies.
- Introduce the "dev" Setuptools extra for development, which includes the former test dependencies.
- Replace `setup.py test` with `-m unittest discover pZudoku`.
- Close #97.

Going forward, the tests should still be runnable with the base dependencies. Coverage is installed so that don't have to run the tests twice (once without and once with coverage).

References:
https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras
