### PR TITLE
Drop support for old NumPy versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You'll need Python 3 installed (3.4 or later), as well as the following
 packages.
 - `pip >= 9.0.0`
 - `setuptools >= 38.6.0`
-- `numpy >= 1.8.0`
+- `numpy >= 1.15.0`
 
 [//]: # (Note: keep these in sync with setup.py's install_requires)
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setuptools.setup(
         "pip >= 9.0.0",
         # setuptools 38.6.0 introduces long_description_content_type
         "setuptools >= 38.6.0",
-        # NumPy 1.8.0 introduces np.full()
-        "numpy >= 1.8.0",
+        # NumPy 1.14 is not supported since 7th of January 2020
+        "numpy >= 1.15.0",
     ],
 
     python_requires=">=3.4",


### PR DESCRIPTION
Drop support for old NumPy versions. NumPy 1.14 is not supported any more. See https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table.