### PR TITLE
General cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,3 @@ __pycache__/
 .coverage
 coverage.xml
 htmlcov/
-
-# Environments
-venv/
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ script:
   # Install the dependencies of the "dev" extra
   - python -m pip install .[dev]
   # Run the PEP8 code style checks
-  - flake8 --filename=*.py --ignore= --exclude=venv,.eggs .
+  - flake8 --filename=*.py --ignore= --exclude=.git,.eggs .
   # Codecov report
   - codecov


### PR DESCRIPTION
- Clean up `.gitignore`. (The `venv/` directory wasn't used.)
- Clean up the flake8 script. (I'm not sure whether there are Python source files inside `.git/`.)