### PR TITLE
Fix the missing Codecov report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
 commands =
     python -m unittest discover pZudoku
 
-[testenv:code_coverage]
+[testenv:numpylatest-code_coverage]
 commands =
 ;   Run tests and compute code coverage
     coverage run -m unittest discover pZudoku

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands =
     python -m unittest discover pZudoku
 
 [testenv:numpylatest-code_coverage]
+passenv = CI TRAVIS TRAVIS_*
 commands =
 ;   Run tests and compute code coverage
     coverage run -m unittest discover pZudoku


### PR DESCRIPTION
PR #108 introduced a regression, and in effect `codecov` is not run.

The `NAME` used in a `[testenv:NAME]` environment setting should not refer to a factor (environment name part); it should be the whole environment name. This PR fixes that.