### PR TITLE
Test against all built distributions of NumPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
 env:
   - TOX_PARALLEL_NO_SPINNER="1"
 
+cache:
+  directories:
+    - .tox/virtualenvs/
+
 install:
   # Install conda via Miniconda. Source:
   # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,7 @@ install:
   - conda activate py37-conda-env
 
 script:
+  # Create tox test environments serially. See tox-dev/tox-conda#39
+  - tox -v --notest
   # Run continuous integration steps using Tox
-  - tox -v
+  - tox -v --parallel auto --parallel-live

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r
+  # Upgrade conda to the latest version
+  - conda update --quiet conda
   # Automatically choose the 'yes' option whenever asked to proceed with a conda operation
   - conda config --set always_yes yes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
 
 script:
   # Run continuous integration steps using Tox
-  - tox -v --parallel auto --parallel-live
+  - tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ matrix:
 env:
   - TOX_PARALLEL_NO_SPINNER="1"
 
-cache:
-  directories:
-    - .tox/virtualenvs/
-
 install:
   # Install conda via Miniconda. Source:
   # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r
-  # Upgrade conda to the latest version
-  - conda update --quiet conda
   # Automatically choose the 'yes' option whenever asked to proceed with a conda operation
   - conda config --set always_yes yes
+  # Upgrade conda to the latest version
+  - conda update --quiet conda
 
   # Create a conda environment with Python 3.7
   - conda create --quiet --name=py37-conda-env python=3.7

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Python 3 implementation of a sudoku solver, using my own 6D boolean array data
 
 You'll need Python 3 installed (3.4 or later), as well as the following
 packages.
-- `numpy >= 1.15.0`
+- NumPy (version 1.14.5 or later)
 
 [//]: # (Note: keep these in sync with setup.py's install_requires)
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
 
     # Run time requirements
     install_requires=[
-        # With test against NumPy 1.14.5 and later
+        # We test against NumPy 1.14.5 and later
         "numpy >= 1.14.5",
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ setuptools.setup(
 
     # Run time requirements
     install_requires=[
-        # NumPy 1.14 is not supported since 7th of January 2020
-        "numpy >= 1.15.0",
+        # With test against NumPy 1.14.5 and later
+        "numpy >= 1.14.5",
     ],
 
     python_requires=">=3.4",

--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,9 @@ conda_deps =
     numpy1174: numpy==1.17.4
     numpy1175: numpy==1.17.5
 
-    numpy1180: numpy==1.18.0
+    ; NumPy 1.18.0, 1.18.2 and 1.18.3 are unavailable in the conda-forge channel,
+    ; so they're installed from PyPI
     numpy1181: numpy==1.18.1
-    numpy1182: numpy==1.18.2
-    numpy1183: numpy==1.18.3
 
     numpylatest: numpy>=1.18.4
 
@@ -53,6 +52,12 @@ conda_deps =
     code_coverage: codecov >= 2.0.0
 
     linting: flake8 >= 3.4
+
+; Dependencies installed using pip
+deps =
+    numpy1180: numpy==1.18.0
+    numpy1182: numpy==1.18.2
+    numpy1183: numpy==1.18.3
 
 ; Fail if NumPy is only available as a source distribution
 install_command = python -m pip install --only-binary=numpy {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,9 @@ conda_deps =
     numpy1180: numpy==1.18.0
     numpy1181: numpy==1.18.1
     numpy1182: numpy==1.18.2
+    numpy1183: numpy==1.18.3
 
-    numpylatest: numpy>=1.18.3
+    numpylatest: numpy>=1.18.4
 
     code_coverage: coverage >= 4.5.2
     code_coverage: codecov >= 2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,17 +3,48 @@
 requires =
     setuptools >= 38.6.0
 envlist =
-    numpy{earliest,116,117,latest}
+    numpy{1145,1146}
+    numpy{1150,1151,1152,1153,1154}
+    numpy{1160,1161,1162,1163,1164,1165,1166}
+    numpy{1170,1171,1172,1173,1174,1175}
+    numpy{1180,1181,1182}
+    numpylatest
     numpylatest-code_coverage
     linting
 
 [testenv]
 envdir = {toxworkdir}/virtualenvs/{envname}
 deps =
-    numpyearliest: numpy==1.15.0
-    numpy116: numpy>=1.16.0,<1.17.0
-    numpy117: numpy>=1.17.0,<1.18.0
-    numpylatest: numpy>=1.18.0
+;   Test against all built distributions of NumPy available for Ubuntu on PyPI
+    numpy1145: numpy==1.14.5
+    numpy1146: numpy==1.14.6
+
+    numpy1150: numpy==1.15.0
+    numpy1151: numpy==1.15.1
+    numpy1152: numpy==1.15.2
+    numpy1153: numpy==1.15.3
+    numpy1154: numpy==1.15.4
+
+    numpy1160: numpy==1.16.0
+    numpy1161: numpy==1.16.1
+    numpy1162: numpy==1.16.2
+    numpy1163: numpy==1.16.3
+    numpy1164: numpy==1.16.4
+    numpy1165: numpy==1.16.5
+    numpy1166: numpy==1.16.6
+
+    numpy1170: numpy==1.17.0
+    numpy1171: numpy==1.17.1
+    numpy1172: numpy==1.17.2
+    numpy1173: numpy==1.17.3
+    numpy1174: numpy==1.17.4
+    numpy1175: numpy==1.17.5
+
+    numpy1180: numpy==1.18.0
+    numpy1181: numpy==1.18.1
+    numpy1182: numpy==1.18.2
+
+    numpylatest: numpy>=1.18.3
 
     code_coverage: coverage >= 4.5.2
     code_coverage: codecov >= 2.0.0
@@ -22,6 +53,9 @@ deps =
 
 commands =
     python -m unittest discover pZudoku
+
+[testenv:numpylatest]
+install_command = python -m pip install --upgrade {opts} {packages}
 
 [testenv:numpylatest-code_coverage]
 passenv = CI TRAVIS TRAVIS_*

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist =
 envdir = {toxworkdir}/virtualenvs/{envname}
 conda_channels = conda-forge
 conda_deps =
-;   Test against all built distributions of NumPy available for Ubuntu on PyPI
+;   Test against all built distributions of NumPy available for Python 3.7 in conda-forge
     numpy1145: numpy==1.14.5
     numpy1146: numpy==1.14.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ conda_deps =
     ; so they're installed from PyPI
     numpy1181: numpy==1.18.1
 
+    ; The below version should be kept in sync with the one in `commands`
     numpylatest: numpy>=1.18.4
 
     code_coverage: coverage >= 4.5.2
@@ -60,10 +61,13 @@ deps =
     numpy1183: numpy==1.18.3
 
 commands =
+    ; Upgrade to the latest NumPy version even if there's one already present
+    ; This version should be kept in sync with the one in `conda_deps`
+    numpylatest: conda install --yes --prefix {envdir} --channel conda-forge python=3.7 'numpy>=1.18.4' --force-reinstall
     python -m unittest discover pZudoku
 
 [testenv:numpylatest]
-install_command = python -m pip install --upgrade {opts} {packages}
+whitelist_externals = conda
 
 [testenv:numpylatest-code_coverage]
 passenv = CI TRAVIS TRAVIS_*

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     numpy{1150,1151,1152,1153,1154}
     numpy{1160,1161,1162,1163,1164,1165,1166}
     numpy{1170,1171,1172,1173,1174,1175}
-    numpy{1180,1181,1182}
+    numpy{1180,1181,1182,1183}
     numpylatest
     numpylatest-code_coverage
     linting

--- a/tox.ini
+++ b/tox.ini
@@ -59,9 +59,6 @@ deps =
     numpy1182: numpy==1.18.2
     numpy1183: numpy==1.18.3
 
-; Fail if NumPy is only available as a source distribution
-install_command = python -m pip install --only-binary=numpy {opts} {packages}
-
 commands =
     python -m unittest discover pZudoku
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,9 @@ deps =
 
     linting: flake8 >= 3.4
 
+; Fail if NumPy is only available as a source distribution
+install_command = python -m pip install --only-binary=numpy {opts} {packages}
+
 commands =
     python -m unittest discover pZudoku
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ conda_deps =
     ; so they're installed from PyPI
     numpy1181: numpy==1.18.1
 
-    ; The below version should be kept in sync with the one in `commands`
     numpylatest: numpy>=1.18.4
 
     code_coverage: coverage >= 4.5.2
@@ -61,13 +60,11 @@ deps =
     numpy1183: numpy==1.18.3
 
 commands =
-    ; Upgrade to the latest NumPy version even if there's one already present
-    ; This version should be kept in sync with the one in `conda_deps`
-    numpylatest: conda install --yes --prefix {envdir} --channel conda-forge python=3.7 'numpy>=1.18.4' --force-reinstall
     python -m unittest discover pZudoku
 
 [testenv:numpylatest]
-whitelist_externals = conda
+; Separate envdir to be able *not to* cache this one
+envdir = {toxworkdir}/numpylatest-venv
 
 [testenv:numpylatest-code_coverage]
 passenv = CI TRAVIS TRAVIS_*

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ envlist =
 
 [testenv]
 envdir = {toxworkdir}/virtualenvs/{envname}
+conda_channels = conda-forge
 conda_deps =
 ;   Test against all built distributions of NumPy available for Ubuntu on PyPI
     numpy1145: numpy==1.14.5


### PR DESCRIPTION
Test against all built distributions of NumPy that are available on the conda-forge channel of conda.

From now on we support NumPy versions as early as 1.14.5 even if they are officially out of date.
https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table