### PR TITLE
Use conda for package management and environment creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda create --quiet --name=py38-conda-env python=3.8
   # Install tox and tox-conda from the appropriate channel
   - conda install --name=py38-conda-env --channel=conda-forge 'tox>=3.0.0' tox-conda
-  - conda activate conda-env
+  - conda activate py38-conda-env
 
 script:
   # Run continuous integration steps using Tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ install:
   # Automatically choose the 'yes' option whenever asked to proceed with a conda operation
   - conda config --set always_yes yes
 
-  - conda create --quiet --name=py38-conda-env python=3.8 'tox>=3.0.0'
-  # Install tox-conda from the appropriate channel
-  - conda install --name=py38-conda-env --channel=conda-forge tox-conda
+  # Create a conda environment with Python 3.8
+  - conda create --quiet --name=py38-conda-env python=3.8
+  # Install tox and tox-conda from the appropriate channel
+  - conda install --name=py38-conda-env --channel=conda-forge 'tox>=3.0.0' tox-conda
   - conda activate conda-env
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-language: python
+language: general
 
 matrix:
   include:
-    # Different Ubuntu images and Python versions to run tests with
-    # Enumerate all possible combinations, because the other option doesn't seem to work
     - os: linux
       dist: xenial
-      python: "3.8"
   # Only wait for required builds to finish
   fast_finish: true
 
@@ -18,8 +15,20 @@ cache:
     - .tox/virtualenvs/
 
 install:
-  # Install the latest available Tox
-  - python -m pip install --upgrade 'tox>=3.0.0'
+  # Install conda via Miniconda. Source:
+  # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/
+  # use-conda-with-travis-ci.html#the-travis-yml-file
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - hash -r
+  # Automatically choose the 'yes' option whenever asked to proceed with a conda operation
+  - conda config --set always_yes yes
+
+  - conda create --quiet --name=py38-conda-env python=3.8 'tox>=3.0.0'
+  # Install tox-conda from the appropriate channel
+  - conda install --name=py38-conda-env --channel=conda-forge tox-conda
+  - conda activate conda-env
 
 script:
   # Run continuous integration steps using Tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ install:
   # Automatically choose the 'yes' option whenever asked to proceed with a conda operation
   - conda config --set always_yes yes
 
-  # Create a conda environment with Python 3.8
-  - conda create --quiet --name=py38-conda-env python=3.8
+  # Create a conda environment with Python 3.7
+  - conda create --quiet --name=py37-conda-env python=3.7
   # Install tox and tox-conda from the appropriate channel
-  - conda install --name=py38-conda-env --channel=conda-forge 'tox>=3.0.0' tox-conda
-  - conda activate py38-conda-env
+  - conda install --name=py37-conda-env --channel=conda-forge 'tox>=3.0.0' tox-conda
+  - conda activate py37-conda-env
 
 script:
   # Run continuous integration steps using Tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 # Manage Python virtual environments for continuous integration and testing
 [tox]
 requires =
+    tox-conda
     setuptools >= 38.6.0
 envlist =
     numpy{earliest,116,117,latest}
@@ -9,7 +10,7 @@ envlist =
 
 [testenv]
 envdir = {toxworkdir}/virtualenvs/{envname}
-deps =
+conda_deps =
     numpyearliest: numpy==1.15.0
     numpy116: numpy>=1.16.0,<1.17.0
     numpy117: numpy>=1.17.0,<1.18.0


### PR DESCRIPTION
- Use conda for package management inside test environments (instead of pip), so that old NumPy installs are easier,
- use conda for the test environments of tox (with the help of tox-conda), because conda can't install to environments created by tox (i.e. by virtualenv),
- manage the base Python executable with conda (simply for convenience),
- change the Travis CI build environment to "general", and
- change the Python version to 3.7 (since NumPy 1.15 of the "conda-forge" channel doesn't install on Python 3.8).

Using conda with Travis CI: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html#the-travis-yml-file
Relevant Travis CI build for the NumPy 1.15 issue: https://travis-ci.com/github/pzahemszky/pZudoku/builds/164891061#L562.
