### PR TITLE
Create tox test environments serially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
   - hash -r
   # Automatically choose the 'yes' option whenever asked to proceed with a conda operation
   - conda config --set always_yes yes
+  # Upgrade conda to the latest version
+  - conda update --quiet conda
 
   # Create a conda environment with Python 3.7
   - conda create --quiet --name=py37-conda-env python=3.7
@@ -32,5 +34,7 @@ install:
   - conda activate py37-conda-env
 
 script:
+  # Create tox test environments serially. See tox-dev/tox-conda#39
+  - tox -v --notest
   # Run continuous integration steps using Tox
   - tox -v --parallel auto --parallel-live


### PR DESCRIPTION
Fix following PR #113 that introduced a failure on `master`: create the tox test environments serially to avoid concurrent calls to `conda create`. See tox-dev/tox-conda#39.