### PR TITLE
Remove the 'dev' extra from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,6 @@ setuptools.setup(
     ],
 
     python_requires=">=3.4",
-    extras_require={
-        "dev": ["flake8 >= 3.4", "coverage >= 4.5.2", "codecov >= 2.0.0"],
-    },
 
     project_urls={
         "Tracker": "https://github.com/pzahemszky/pZudoku/issues",


### PR DESCRIPTION
Remove the 'dev' extra from `setup.py`.

Versions of packages that are not dependencies of the package are not tracked from now on.