### PR TITLE
Remove the tox test environment caching in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ matrix:
 env:
   - TOX_PARALLEL_NO_SPINNER="1"
 
-cache:
-  directories:
-    - .tox/virtualenvs/
-
 install:
   # Install conda via Miniconda. Source:
   # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/


### PR DESCRIPTION
Remove the tox test environment caching in Travis CI. It doesn't speed things up.